### PR TITLE
Add PostgreSQL database support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,17 @@ require (
 	github.com/stretchr/testify v1.8.1
 	gopkg.in/telebot.v3 v3.2.1
 	gorm.io/driver/sqlite v1.5.7
-	gorm.io/gorm v1.25.9
+	gorm.io/gorm v1.25.10
 )
 
 require (
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
+	github.com/jackc/pgx/v5 v5.6.0 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -24,7 +28,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/postgres v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,14 @@ github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
+github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
+github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
+github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
@@ -411,6 +419,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
+golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -528,6 +538,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
+golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -873,10 +885,14 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
+gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
 gorm.io/driver/sqlite v1.5.7 h1:8NvsrhP0ifM7LX9G4zPB97NwovUakUxc+2V2uuf3Z1I=
 gorm.io/driver/sqlite v1.5.7/go.mod h1:U+J8craQU6Fzkcvu8oLeAQmi50TkwPEhHDEjQZXDah4=
 gorm.io/gorm v1.25.9 h1:wct0gxZIELDk8+ZqF/MVnHLkA1rvYlBWUMv2EdsK1g8=
 gorm.io/gorm v1.25.9/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
+gorm.io/gorm v1.25.10 h1:dQpO+33KalOA+aFYGlK+EfxcI5MbO7EP2yYygwh9h+s=
+gorm.io/gorm v1.25.10/go.mod h1:hbnx/Oo0ChWMn1BIhpy1oYozzpM15i4YPuHDmfYtwg8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internals/database/database.go
+++ b/internals/database/database.go
@@ -1,6 +1,8 @@
 package database
 
 import (
+	"fmt"
+	"gorm.io/driver/postgres" // New import
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"os"
@@ -8,21 +10,45 @@ import (
 
 type DbParams struct {
 	File string
+	Type string
 }
 
 func InitDbParams() *DbParams {
+	dbType := os.Getenv("ECHOPAN_DB_TYPE")
+	if dbType == "" {
+		dbType = "sqlite"
+	}
 	return &DbParams{
 		File: os.Getenv("ECHOPAN_DB_FILE"),
+		Type: dbType,
 	}
 }
 
 func DbConnect(params *DbParams) *gorm.DB {
-	if params.File == "" {
-		panic("database file path is required")
+	var db *gorm.DB
+	var err error
+
+	switch params.Type {
+	case "sqlite":
+		if params.File == "" {
+			panic("database file path (ECHOPAN_DB_FILE) is required for sqlite")
+		}
+		db, err = gorm.Open(sqlite.Open(params.File), &gorm.Config{})
+		if err != nil {
+			panic(fmt.Sprintf("failed to connect to sqlite database: %s", err.Error()))
+		}
+	case "postgres":
+		dsn := os.Getenv("ECHOPAN_DB_DSN_POSTGRES")
+		if dsn == "" {
+			panic("PostgreSQL DSN (ECHOPAN_DB_DSN_POSTGRES) is required when DB type is postgres")
+		}
+		db, err = gorm.Open(postgres.Open(dsn), &gorm.Config{})
+		if err != nil {
+			panic(fmt.Sprintf("failed to connect to postgres database: %s", err.Error()))
+		}
+	default:
+		panic(fmt.Sprintf("Unsupported database type: %s", params.Type))
 	}
-	db, err := gorm.Open(sqlite.Open(params.File), &gorm.Config{})
-	if err != nil {
-		panic("failed to connect database: " + err.Error())
-	}
+
 	return db
 }

--- a/internals/database/database_test.go
+++ b/internals/database/database_test.go
@@ -7,42 +7,90 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInitDbParams_WithEnvVar(t *testing.T) {
+// Tests for InitDbParams
+func TestInitDbParams_WithEnvVarFile(t *testing.T) {
 	expectedFile := "test.db"
 	os.Setenv("ECHOPAN_DB_FILE", expectedFile)
 	defer os.Unsetenv("ECHOPAN_DB_FILE")
 
+	// Ensure DB_TYPE is not set or default for this specific test
+	originalDbType := os.Getenv("ECHOPAN_DB_TYPE")
+	os.Unsetenv("ECHOPAN_DB_TYPE")
+	defer os.Setenv("ECHOPAN_DB_TYPE", originalDbType)
+
 	params := InitDbParams()
 	assert.Equal(t, expectedFile, params.File)
+	assert.Equal(t, "sqlite", params.Type, "Default type should be sqlite")
 }
 
-func TestInitDbParams_WithoutEnvVar(t *testing.T) {
-	// Ensure the environment variable is not set
+func TestInitDbParams_WithoutEnvVarFile(t *testing.T) {
 	os.Unsetenv("ECHOPAN_DB_FILE")
+
+	originalDbType := os.Getenv("ECHOPAN_DB_TYPE")
+	os.Unsetenv("ECHOPAN_DB_TYPE")
+	defer os.Setenv("ECHOPAN_DB_TYPE", originalDbType)
 
 	params := InitDbParams()
 	assert.Equal(t, "", params.File)
+	assert.Equal(t, "sqlite", params.Type, "Default type should be sqlite")
 }
 
-func TestDbConnect_InMemory(t *testing.T) {
-	params := &DbParams{File: ":memory:"} // Use in-memory SQLite database
+func TestInitDbParams_DbTypePostgres(t *testing.T) {
+	os.Setenv("ECHOPAN_DB_TYPE", "postgres")
+	defer os.Unsetenv("ECHOPAN_DB_TYPE")
+	params := InitDbParams()
+	assert.Equal(t, "postgres", params.Type)
+}
+
+func TestInitDbParams_DbTypeSqlite(t *testing.T) {
+	os.Setenv("ECHOPAN_DB_TYPE", "sqlite")
+	defer os.Unsetenv("ECHOPAN_DB_TYPE")
+	params := InitDbParams()
+	assert.Equal(t, "sqlite", params.Type)
+}
+
+func TestInitDbParams_DbTypeEmptyDefaultsToSqlite(t *testing.T) {
+	originalDbType := os.Getenv("ECHOPAN_DB_TYPE")
+	os.Unsetenv("ECHOPAN_DB_TYPE") // Ensure it's empty or not set
+	defer os.Setenv("ECHOPAN_DB_TYPE", originalDbType)
+
+	params := InitDbParams()
+	assert.Equal(t, "sqlite", params.Type)
+}
+
+func TestInitDbParams_DbTypeUnsupported(t *testing.T) {
+	os.Setenv("ECHOPAN_DB_TYPE", "nosuchdb")
+	defer os.Unsetenv("ECHOPAN_DB_TYPE")
+	params := InitDbParams()
+	assert.Equal(t, "nosuchdb", params.Type) // InitDbParams should still set it
+}
+
+// Tests for DbConnect - SQLite
+func TestDbConnect_SQLite_InMemory(t *testing.T) {
+	params := &DbParams{File: ":memory:", Type: "sqlite"} // Use in-memory SQLite database
 	db := DbConnect(params)
 	assert.NotNil(t, db, "Database connection should not be nil for in-memory database")
 
-	// Optional: Test if the database is usable by performing a simple query
 	var result int
 	err := db.Raw("SELECT 1").Scan(&result).Error
 	assert.NoError(t, err, "Should be able to execute a simple query on in-memory DB")
 	assert.Equal(t, 1, result, "Query result should be 1")
+
+	sqlDB, _ := db.DB()
+	sqlDB.Close()
 }
 
-func TestDbConnect_ValidFile(t *testing.T) {
+func TestDbConnect_SQLite_ValidFile(t *testing.T) {
 	tempFile := "test_echopan.db"
-	params := &DbParams{File: tempFile}
+	// Ensure ECHOPAN_DB_FILE is not interfering, though DbConnect directly uses params.File
+	originalDbFile := os.Getenv("ECHOPAN_DB_FILE")
+	os.Unsetenv("ECHOPAN_DB_FILE")
+	defer os.Setenv("ECHOPAN_DB_FILE", originalDbFile)
+
+	params := &DbParams{File: tempFile, Type: "sqlite"}
 	db := DbConnect(params)
 	assert.NotNil(t, db, "Database connection should not be nil for a valid file")
 
-	// Clean up the created database file
 	sqlDB, err := db.DB()
 	assert.NoError(t, err, "Failed to get underlying sql.DB")
 	err = sqlDB.Close()
@@ -51,28 +99,88 @@ func TestDbConnect_ValidFile(t *testing.T) {
 	assert.NoError(t, err, "Failed to remove temporary database file")
 }
 
-func TestDbConnect_PanicsWithInvalidFile(t *testing.T) {
-	// Provide an invalid path that GORM cannot write to
-	// For example, a path that includes a non-existent directory,
-	// or a path that would require root permissions.
-	// SQLite creates a file if it doesn't exist, so we need a path that's truly unwritable.
-	// A common trick for this on Unix-like systems is to point to a directory as a file.
-	// However, for cross-platform compatibility and simplicity,
-	// we'll test the panic by checking the panic message.
-	// GORM's behavior with truly invalid paths can sometimes be creating the file anyway if possible,
-	// so we rely on the "failed to connect database" panic message which is specific to our code.
+func TestDbConnect_SQLite_PanicsWithInvalidFile(t *testing.T) {
+	params := &DbParams{File: "/this/path/should/not/be/writable/test.db", Type: "sqlite"}
 
-	params := &DbParams{File: "/this/path/should/not/be/writable/test.db"} // Invalid path
-
-	assert.PanicsWithValue(t, "failed to connect database: unable to open database file: no such file or directory", func() {
+	// expectedPanicMsg := fmt.Sprintf("failed to connect to sqlite database: unable to open database file: /this/path/should/not/be/writable/test.db")
+	// Note: GORM v1.25.x includes the filename in the error, previous versions might not.
+	// We are checking if the panic occurs, the exact message can be tricky if GORM changes its internal error strings.
+	// For now, let's assert that it panics. A more robust check might involve a regex or Contains.
+	// For this case, we'll try to match the common part of the error.
+	assert.PanicsWithValue(t, "failed to connect to sqlite database: unable to open database file: no such file or directory", func() {
 		DbConnect(params)
-	}, "DbConnect should panic with 'failed to connect database' for an invalid file path")
+	}, "DbConnect should panic with 'failed to connect to sqlite database: unable to open database file: no such file or directory' for an invalid file path.")
 }
 
-func TestDbConnect_PanicsWithEmptyFile(t *testing.T) {
-	params := &DbParams{File: ""} // Empty file path
+func TestDbConnect_SQLite_PanicsWithEmptyFile(t *testing.T) {
+	params := &DbParams{File: "", Type: "sqlite"} // Empty file path, explicitly sqlite
 
-	assert.PanicsWithValue(t, "database file path is required", func() {
+	assert.PanicsWithValue(t, "database file path (ECHOPAN_DB_FILE) is required for sqlite", func() {
 		DbConnect(params)
-	}, "DbConnect should panic with 'failed to connect database' for an empty file path")
+	}, "DbConnect should panic for an empty file path with sqlite type")
+}
+
+// Tests for DbConnect - PostgreSQL
+func TestDbConnect_Postgres_Success(t *testing.T) {
+	dsn := os.Getenv("ECHOPAN_TEST_DB_DSN_POSTGRES")
+	if dsn == "" {
+		t.Skip("Skipping PostgreSQL connection test: ECHOPAN_TEST_DB_DSN_POSTGRES not set")
+	}
+
+	// DbConnect reads ECHOPAN_DB_DSN_POSTGRES directly, so set it for the test scope
+	originalDsnEnv := os.Getenv("ECHOPAN_DB_DSN_POSTGRES")
+	os.Setenv("ECHOPAN_DB_DSN_POSTGRES", dsn)
+	defer os.Setenv("ECHOPAN_DB_DSN_POSTGRES", originalDsnEnv)
+
+	params := &DbParams{Type: "postgres"} // File field is not used for postgres
+	db := DbConnect(params)
+	assert.NotNil(t, db, "PostgreSQL connection should not be nil")
+
+	var result int
+	err := db.Raw("SELECT 1").Scan(&result).Error
+	assert.NoError(t, err, "Should be able to execute a simple query on PostgreSQL DB")
+	assert.Equal(t, 1, result, "Query result should be 1")
+
+	sqlDB, _ := db.DB()
+	sqlDB.Close()
+}
+
+func TestDbConnect_Postgres_PanicsWithEmptyDSN(t *testing.T) {
+	originalDsnEnv := os.Getenv("ECHOPAN_DB_DSN_POSTGRES")
+	os.Unsetenv("ECHOPAN_DB_DSN_POSTGRES") // Ensure DSN is not set
+	defer os.Setenv("ECHOPAN_DB_DSN_POSTGRES", originalDsnEnv)
+
+	params := &DbParams{Type: "postgres"}
+
+	assert.PanicsWithValue(t, "PostgreSQL DSN (ECHOPAN_DB_DSN_POSTGRES) is required when DB type is postgres", func() {
+		DbConnect(params)
+	}, "DbConnect should panic when DSN is empty for postgres type")
+}
+
+func TestDbConnect_Postgres_PanicsWithInvalidDSN(t *testing.T) {
+	invalidDsn := "this-is-not-a-valid-dsn"
+	originalDsnEnv := os.Getenv("ECHOPAN_DB_DSN_POSTGRES")
+	os.Setenv("ECHOPAN_DB_DSN_POSTGRES", invalidDsn)
+	defer os.Setenv("ECHOPAN_DB_DSN_POSTGRES", originalDsnEnv)
+
+	params := &DbParams{Type: "postgres"}
+
+	// The exact error message from the driver can vary.
+	// The panic message from our code is "failed to connect to postgres database: %s"
+	// where %s is the error from postgres.Open(dsn)
+	// For "this-is-not-a-valid-dsn", the internal error is typically "cannot parse `this-is-not-a-valid-dsn`: failed to parse as keyword/value (invalid keyword/value)"
+	// or similar depending on the pgx version.
+	expectedPanicValue := "failed to connect to postgres database: cannot parse `this-is-not-a-valid-dsn`: failed to parse as keyword/value (invalid keyword/value)"
+	assert.PanicsWithValue(t, expectedPanicValue, func() {
+		DbConnect(params)
+	}, "DbConnect should panic with the specific message for an invalid DSN for postgres type")
+}
+
+// Test for Unsupported Database Type
+func TestDbConnect_PanicsWithUnsupportedType(t *testing.T) {
+	params := &DbParams{Type: "nosuchdb"}
+
+	assert.PanicsWithValue(t, "Unsupported database type: nosuchdb", func() {
+		DbConnect(params)
+	}, "DbConnect should panic for an unsupported database type")
 }


### PR DESCRIPTION
This commit introduces the ability to use PostgreSQL as the database backend, in addition to the existing SQLite option.

Key changes:
- The database type can now be specified using the `ECHOPAN_DB_TYPE` environment variable (`sqlite` or `postgres`). Defaults to `sqlite`.
- For PostgreSQL, the connection DSN is read from the `ECHOPAN_DB_DSN_POSTGRES` environment variable.
- For SQLite, the database file path is still read from `ECHOPAN_DB_FILE`.
- `internals/database/database.go` was updated to handle the new database type, including adding the `gorm.io/driver/postgres` dependency.
- `internals/database/database_test.go` was significantly updated to:
    - Test the `ECHOPAN_DB_TYPE` environment variable in `InitDbParams`.
    - Add comprehensive tests for PostgreSQL connectivity, including successful connection (using `ECHOPAN_TEST_DB_DSN_POSTGRES`), missing DSN, and invalid DSN scenarios.
    - Ensure existing SQLite tests correctly specify the database type and verify updated error messages.
    - Add a test for unsupported database types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to both SQLite and PostgreSQL databases, configurable via environment variables.

- **Bug Fixes**
  - Improved error handling with clear messages for unsupported database types and invalid connection parameters.

- **Tests**
  - Expanded and refined test coverage for database initialization and connection logic, including various configuration scenarios and error cases.

- **Chores**
  - Updated dependencies to include PostgreSQL drivers and related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->